### PR TITLE
Fix LinkedIn URL

### DIFF
--- a/src/data/resume.ts
+++ b/src/data/resume.ts
@@ -61,7 +61,7 @@ export const resume: Resume = {
     photo: '/photo.jpg',
     contact: [
       { kind: 'github', href: 'https://github.com/sepbehroozi', label: 'GitHub' },
-      { kind: 'linkedin', href: 'https://www.linkedin.com/in/sepbehroozi/', label: 'LinkedIn' },
+      { kind: 'linkedin', href: 'https://www.linkedin.com/in/sepehr-behroozi/', label: 'LinkedIn' },
     ],
   },
   about:


### PR DESCRIPTION
The LinkedIn link in `src/data/resume.ts` pointed at `/in/sepbehroozi/` but the actual profile slug is `/in/sepehr-behroozi/`. One-line fix.