### PR TITLE
feat: add EvilSeven privacy policy page

### DIFF
--- a/scripts/smoke-test-urls.sh
+++ b/scripts/smoke-test-urls.sh
@@ -18,6 +18,8 @@ checks=(
   "/4barg/privacy_policy.html|text/html"
   "/4barg/terms_of_service|text/html"
   "/4barg/terms_of_service.html|text/html"
+  "/evilseven/privacy_policy|text/html"
+  "/evilseven/privacy_policy.html|text/html"
   "/sepool/privacy_policy|text/html"
   "/sepool/privacy_policy.html|text/html"
   "/sepool/terms_of_service|text/html"

--- a/src/pages/evilseven/privacy_policy.md
+++ b/src/pages/evilseven/privacy_policy.md
@@ -1,0 +1,107 @@
+---
+layout: ../../layouts/Legal.astro
+title: Privacy Policy — EvilSeven
+description: Privacy policy for the EvilSeven mobile game.
+---
+
+**Privacy Policy**
+
+This privacy policy applies to the EvilSeven app for mobile devices, together with any related services operated by Sep Behroozi (collectively, the "Application"). Sep Behroozi is hereby referred to as the "Service Provider".
+
+**Information Collection and Use**
+
+The Application collects information when you download and use it. This information may include information such as
+
+*   Your device's Internet Protocol address
+*   The pages of the Application that you visit, the time and date of your visit, the time spent on those pages
+*   The time spent on the Application
+*   Your mobile operating system you use
+
+**Cookies and tracking technologies**
+
+The Application or its third-party SDKs may use cookies, SDKs, pixels, and similar technologies to support functionality, analytics, or service delivery. Where required by applicable law, the Service Provider will obtain consent before using non-essential tracking technologies.
+
+**Your Rights**
+
+You may request access to, correction of, or deletion of your personal data held by the Service Provider. To exercise these rights, or to withdraw consent where processing is based on consent, contact the Service Provider at efromfb@gmail.com.
+
+**Your California privacy rights (CCPA/CPRA)**
+
+If you are a California resident, you have the right to know what personal information is collected, the right to delete personal information, the right to opt out of the sale or sharing of personal information, and the right to non-discrimination for exercising these rights. To exercise your CCPA/CPRA rights, contact the Service Provider at efromfb@gmail.com.
+
+The Service Provider may use the information you provide to send important information, required notices, and, where permitted by law, marketing communications.
+
+For a better experience while using the Application, the Service Provider may require you to provide certain personally identifiable information, including but not limited to email, phone, device ID, user ID, advertisement ID. The information the Service Provider requests will be retained and used as described in this privacy policy.
+
+**Third Party Access**
+
+Only aggregated, anonymized data is periodically transmitted to external services to aid the Service Provider in improving the Application and their service. The Service Provider may share your information with third parties in the ways that are described in this privacy statement.
+
+**International Data Transfers**
+
+The Service Provider or its third-party service providers may transfer personal data to countries outside your country of residence, including outside the European Economic Area (EEA). Where applicable law requires safeguards for international transfers, the Service Provider will use appropriate mechanisms.
+
+*   Standard Contractual Clauses (SCCs) approved by the European Commission
+*   Adequacy decisions or other legally recognized transfer mechanisms
+*   Your consent, where required and legally permitted
+
+Data protection laws in other countries may differ from those in your jurisdiction. Where required by law, the Service Provider will apply appropriate safeguards and obtain any consent required for the transfer.
+
+Please note that the Application utilizes third-party services that have their own Privacy Policy about handling data. Below are the links to the Privacy Policy of the third-party service providers used by the Application:
+
+*   [TapsellPlus](https://developer.tapsell.ir/docs/sdk/1.1.x/policies/privacy-policy/)
+*   [Firebase Crashlytics](https://firebase.google.com/support/privacy/)
+*   [Sentry](https://sentry.io/privacy/)
+
+The Service Provider may disclose User Provided and Automatically Collected Information:
+
+*   as required by law, such as to comply with a subpoena, or similar legal process;
+*   when they believe in good faith that disclosure is necessary to protect their rights, protect your safety or the safety of others, investigate fraud, or respond to a government request;
+*   with their trusted services providers who work on their behalf, do not have an independent use of the information the Service Provider discloses to them, and have agreed to adhere to the rules set forth in this privacy statement.
+
+**Opt-Out Rights**
+
+You can stop further collection of information from your mobile device by uninstalling the Application. Uninstalling will stop the Application from collecting data from your device, but it does not automatically delete information that has already been transmitted to the Service Provider or to third parties.
+
+To request deletion of your personal data, to withdraw consent, or to exercise any of your rights, contact the Service Provider at efromfb@gmail.com.
+
+**Data Retention Policy**
+
+The Service Provider retains personal data based on its necessity for the stated purposes:
+
+*   User Provided Data: Retained for the duration of your use of the Application plus 12 months thereafter, unless longer retention is required by law
+*   Automatically Collected Data: Retained for up to 24 months from collection, unless longer retention is required for legal compliance
+*   Aggregated and Anonymized Data: Retained indefinitely as it no longer identifies you
+*   Data required for legal compliance: Retained as long as required by applicable law
+
+You may request deletion of your personal data, subject to any legal obligation to retain it. If you want the Service Provider to delete User Provided Data submitted through the Application, please contact them at efromfb@gmail.com. Please note that some User Provided Data may be required for the Application to function properly.
+
+**Children**
+
+The Application is not intended for children under 16 years of age, or such higher age as required by applicable law. The Service Provider does not knowingly solicit data from children or market the Application to them.
+
+Where parental or guardian consent is required under applicable law, the Application is not intended for use without that consent. The Service Provider does not knowingly collect personally identifiable information from children under 16 years of age in violation of applicable law. In the event the Service Provider discovers that a child has provided personal information, the Service Provider will immediately delete this from their servers. If you are a parent or guardian and you are aware that your child has provided the Service Provider with personal information, please contact the Service Provider (efromfb@gmail.com) so that they will be able to take the necessary actions.
+
+**Security**
+
+The Service Provider is concerned about safeguarding the confidentiality of your information. The Service Provider provides physical, electronic, and procedural safeguards to protect information the Service Provider processes and maintains.
+
+**Data Breach Notification**
+
+If a data breach occurs that affects your personal data, the Service Provider will notify you in accordance with applicable legal requirements, including, where required, providing information about the nature of the breach and the steps being taken to address it.
+
+**Changes**
+
+The Service Provider may update this Privacy Policy from time to time. The Service Provider will notify you of material changes by posting the updated Privacy Policy with an effective date. Where required by law, the Service Provider will seek your consent to material changes before they take effect.
+
+Previous versions of this Privacy Policy will be maintained and made available upon request by contacting the Service Provider at efromfb@gmail.com.
+
+This privacy policy is effective as of 2026-06-19
+
+**Your Consent**
+
+Where processing is based on consent, you provide that consent by affirmatively opting in to the relevant feature or action. You may withdraw consent at any time without affecting processing carried out before withdrawal. Processing based on other lawful bases is carried out as described above.
+
+**Contact Us**
+
+If you have any questions regarding privacy while using the Application, or have questions about the practices, please contact the Service Provider via email at efromfb@gmail.com.


### PR DESCRIPTION
Adds a privacy policy page for the EvilSeven Android game at `/evilseven/privacy_policy`.

**Changes:**
- Create `src/pages/evilseven/privacy_policy.md` using the shared `Legal.astro` layout
- Third-party services accurately reflect the app's SDKs: TapsellPlus, Firebase Crashlytics, Sentry
- Add smoke test URLs for the new page

**Verification:**
- Build: 11 pages (all pass)
- Smoke test: 22/22 URLs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)